### PR TITLE
fix(A02): correct Dataproc encryption configuration

### DIFF
--- a/terraform/envs/dev/phase2.tf
+++ b/terraform/envs/dev/phase2.tf
@@ -184,7 +184,7 @@ resource "google_dataproc_cluster" "dev_cluster" {
 
     # Encryption configuration
     encryption_config {
-      gce_pd_kms_key_name = module.kms.crypto_key_id
+      kms_key_name = module.kms.crypto_key_id
     }
   }
 


### PR DESCRIPTION
- Fix encryption_config argument from gce_pd_kms_key_name to kms_key_name
- Terraform configuration now validates successfully
- All module dependencies correctly resolved